### PR TITLE
changed modal to now take in children, so that buttons can be passed …

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,9 @@ import { SavedDocument } from './types/saved-document';
 
 function App() {
   const dispatch = useAppDispatch();
-  const { showDeleteModal, document } = useAppSelector((state) => state);
+  const { showTitleModal, showDeleteModal, document } = useAppSelector(
+    (state) => state
+  );
   useEffect(() => {
     dispatch(initializeWelcomeMarkdown());
   }, []);
@@ -40,9 +42,22 @@ function App() {
         <Modal
           title="delete document"
           message="Are you sure you want to delete the current document and its contents? This action cannot be reversed."
-          confirmMethod={confirmDelete}
-          cancelMethod={() => dispatch(removeModal('delete'))}
-        />
+        >
+          <button onClick={confirmDelete}>Confirm & Delete</button>
+          <button onClick={() => dispatch(removeModal('delete'))}>
+            Cancel
+          </button>
+        </Modal>
+      )}
+      {showTitleModal && (
+        <Modal
+          title="Invalid document name"
+          message={`The document title ${
+            document?.currentDocumentTitle || ''
+          } is invalid, please enter a valid document name`}
+        >
+          <button onClick={() => dispatch(removeModal('title'))}>OK</button>
+        </Modal>
       )}
       <TopBar />
       <DocumentEdit />

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,19 +1,19 @@
 interface ModalProps {
   title: string;
   message: string;
-  confirmMethod: () => void;
-  cancelMethod?: () => void;
+  children: React.ReactNode;
 }
 
-const Modal = ({ title, message, confirmMethod, cancelMethod }: ModalProps) => {
+const Modal = ({
+  title,
+  message,
+  children,
+}: ModalProps) => {
   return (
     <div>
       <h3>{title}</h3>
       <p>{message}</p>
-      <div>
-        <button onClick={confirmMethod}>confirm</button>
-        {cancelMethod && <button onClick={cancelMethod}>cancel</button>}
-      </div>
+      <div>{children}</div>
     </div>
   );
 };

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -28,7 +28,7 @@ const TopBar = () => {
     if (!document) return;
 
     if (!validDocumentTitle.test(document.currentDocumentTitle)) {
-      console.log('invalid document title');
+      dispatch(displayModal('title'));
       return;
     }
 


### PR DESCRIPTION
…in directly to the modal instead of passing in the methods, this makes it easier to customize the button text depending on the context, confirmed that a modal appears when a user attempts to save a document with a invalid name, whether it is a new document or not