### PR TITLE
apply a keyframe that makes the element visibility hidden when not on…

### DIFF
--- a/src/components/Menu/Menu.styled.ts
+++ b/src/components/Menu/Menu.styled.ts
@@ -1,8 +1,30 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 
 interface MenuStyledProps {
   menuVisible: boolean;
 }
+
+const slideIn = keyframes`
+  from{
+    visibility: visible;
+    transform: translateX(-23rem);
+  }
+  to{
+    transform: translateX(0);
+  }
+`;
+
+const slideOut = keyframes`
+  from {
+    visibility: visible;
+    transform: translateX(0);
+  }
+
+  to{
+    visibility: hidden;
+    transform: translateX(-23rem);
+  }
+`;
 
 const MenuStyled = styled.section<MenuStyledProps>`
   position: fixed;
@@ -10,9 +32,12 @@ const MenuStyled = styled.section<MenuStyledProps>`
   left: 0;
   transition: transform 0.2s ease-in;
   min-width: 23rem;
-  transform: ${({ menuVisible }) =>
-    menuVisible ? 'translateX(0)' : 'translateX(-23rem)'};
+  transform: translateX(-23rem);
   height: 100vh;
+
+  animation-name: ${({ menuVisible }) => (menuVisible ? slideIn : slideOut)};
+  animation-duration: 0.25s;
+  animation-fill-mode: forwards;
 `;
 
 export default MenuStyled;


### PR DESCRIPTION
… screen, this is because I dont want screen readers to read out the menu until its on the page, more aria properties will be added later to make this more accessible